### PR TITLE
feat(lazyvim): minor changes to maintain stable

### DIFF
--- a/nvim/lazyvim.json
+++ b/nvim/lazyvim.json
@@ -1,7 +1,5 @@
 {
   "extras": [
-    "lazyvim.plugins.extras.ai.copilot",
-    "lazyvim.plugins.extras.ai.copilot-chat",
     "lazyvim.plugins.extras.coding.nvim-cmp",
     "lazyvim.plugins.extras.dap.core",
     "lazyvim.plugins.extras.editor.mini-diff",
@@ -14,6 +12,8 @@
     "lazyvim.plugins.extras.lang.terraform",
     "lazyvim.plugins.extras.lang.toml",
     "lazyvim.plugins.extras.lang.yaml",
+    "lazyvim.plugins.extras.lang.prisma",
+    "lazyvim.plugins.extras.lang.typescript",
     "lazyvim.plugins.extras.test",
     "lazyvim.plugins.extras.test.core",
     "lazyvim.plugins.extras.util.dot",
@@ -22,7 +22,7 @@
   ],
   "install_version": 8,
   "news": {
-    "NEWS.md": "10960",
+    "NEWS.md": "11866",
     "version": 8
   },
   "version": 8

--- a/nvim/lua/config/efm.lua
+++ b/nvim/lua/config/efm.lua
@@ -23,6 +23,11 @@ local yamllint = require("efmls-configs.linters.yamllint")
 -- local actionlint = require("efmls-configs.linters.actionlint")
 -- css/sccss
 local stylelint = require("efmls-configs.linters.stylelint")
+-- python
+local ruff = require("efmls-configs.linters.ruff")
+local ruff_formatter = require("efmls-configs.formatters.ruff")
+local ruff_sort = require("efmls-configs.formatters.ruff_sort")
+
 local languages = {
   html = { prettier },
   css = { prettier, stylelint },
@@ -37,6 +42,7 @@ local languages = {
   rust = { rustfmt },
   terraform = { terraform_fmt },
   yaml = { prettier, yamllint },
+  python = { ruff, ruff_formatter, ruff_sort },
 }
 
 -- Or use the defaults provided by this plugin

--- a/nvim/lua/plugins/companion.lua
+++ b/nvim/lua/plugins/companion.lua
@@ -5,6 +5,29 @@ return {
     dependencies = {
       "nvim-lua/plenary.nvim",
       "nvim-treesitter/nvim-treesitter",
+      "ravitemer/mcphub.nvim",
+    },
+  },
+  {
+    "HakonHarnes/img-clip.nvim",
+    opts = {
+      filetypes = {
+        codecompanion = {
+          prompt_for_file_name = false,
+          template = "[Image]($FILE_PATH)",
+          use_absolute_path = true,
+        },
+      },
+      extensions = {
+        mcphub = {
+          callback = "mcphub.extensions.codecompanion",
+          opts = {
+            make_vars = true,
+            make_slash_commands = true,
+            show_result_in_chat = true,
+          },
+        },
+      },
     },
   },
 }

--- a/nvim/lua/plugins/copilot.lua
+++ b/nvim/lua/plugins/copilot.lua
@@ -1,19 +1,19 @@
 return {
-  {
-    "zbirenbaum/copilot.lua",
-    opts = {
-      panel = { enabled = false },
-      filetypes = {
-        yaml = true,
-        markdown = true,
-        help = true,
-        gitcommit = true,
-        gitrebase = true,
-        hgcommit = false,
-        svn = false,
-        cvs = false,
-        ["."] = false,
-      },
-    },
-  },
+  -- {
+  --   "zbirenbaum/copilot.lua",
+  --   opts = {
+  --     panel = { enabled = false },
+  --     filetypes = {
+  --       yaml = true,
+  --       markdown = true,
+  --       help = true,
+  --       gitcommit = true,
+  --       gitrebase = true,
+  --       hgcommit = false,
+  --       svn = false,
+  --       cvs = false,
+  --       ["."] = false,
+  --     },
+  --   },
+  -- },
 }

--- a/nvim/lua/plugins/core.lua
+++ b/nvim/lua/plugins/core.lua
@@ -61,6 +61,11 @@ return {
         "markdown",
         "ninja",
         "rst",
+        --- for makefile
+        "clang",
+        "gcc",
+        "make",
+        "cmake",
       },
     },
   },

--- a/nvim/lua/plugins/mini.lua
+++ b/nvim/lua/plugins/mini.lua
@@ -1,6 +1,6 @@
 -- luacheck: ignore
 return {
-  "echasnovski/mini.ai",
+  "nvim-mini/mini.ai",
   event = "VeryLazy",
   opts = function()
     local ai = require("mini.ai")

--- a/nvim/lua/plugins/python.lua
+++ b/nvim/lua/plugins/python.lua
@@ -28,13 +28,17 @@ return {
             },
           },
         },
+        pyright = {
+          mason = false,
+          --  autostart = false,
+        },
       },
       setup = {
         ["ruff"] = function()
-          LazyVim.lsp.on_attach(function(client, _)
+          Snacks.util.lsp.on({ name = "*" }, function(_, client)
             -- Disable hover in favor of Pyright
             client.server_capabilities.hoverProvider = false
-          end, "ruff")
+          end)
         end,
       },
     },


### PR DESCRIPTION
This pull request introduces several updates to the Neovim configuration, focusing on plugin management, language support, and linter/formatter integration. The main themes are the removal of Copilot-related plugins and configuration, the addition of enhanced Python tooling, and expanded support for languages and plugins.

**Plugin and language support updates:**

* Removed Copilot and Copilot Chat plugins from the `lazyvim.json` extras list and commented out their configuration in `plugins/copilot.lua`, effectively disabling Copilot integration. [[1]](diffhunk://#diff-cc257793e75c33d4e14c69b9de490ef8d9b3563067a615e619148c5c254db7e6L3-L4) [[2]](diffhunk://#diff-16659c68e670f4ad385788e0ac05f938be7684b1a69b8faf14510c2b16c4d2a5L2-R18)
* Added Prisma and TypeScript language extras to `lazyvim.json` for improved language support.
* Updated the news version in `lazyvim.json` to reflect recent changes.
* Switched the `mini.ai` plugin source from `echasnovski/mini.ai` to `nvim-mini/mini.ai` in `plugins/mini.lua` for improved plugin management.
* Added support for Makefile-related languages (`clang`, `gcc`, `make`, `cmake`) to the Treesitter configuration in `plugins/core.lua`.

**Python tooling enhancements:**

* Integrated `ruff` linter, `ruff_formatter`, and `ruff_sort` as Python linters/formatters in `efm.lua`, and registered them under the `python` language. [[1]](diffhunk://#diff-6c08640dbb10d26761bdd4bc4a19cae34505d274518e8ce51784f038db2f7948R26-R30) [[2]](diffhunk://#diff-6c08640dbb10d26761bdd4bc4a19cae34505d274518e8ce51784f038db2f7948R45)
* Added explicit `pyright` configuration to the Python LSP setup, disabling Mason management for Pyright and improving LSP attachment logic for Ruff.

**New plugins and extensions:**

* Added `ravitemer/mcphub.nvim` and `HakonHarnes/img-clip.nvim` plugins, including configuration for image handling and Mcphub extension integration in `plugins/companion.lua`.

These changes collectively improve language tooling, streamline plugin usage, and remove unused Copilot integrations.