### PR TITLE
fix(healthckecks): fixed healthchecks

### DIFF
--- a/nvim/lazyvim.json
+++ b/nvim/lazyvim.json
@@ -18,7 +18,10 @@
     "lazyvim.plugins.extras.test.core",
     "lazyvim.plugins.extras.util.dot",
     "lazyvim.plugins.extras.util.gitui",
-    "lazyvim.plugins.extras.vscode"
+    "lazyvim.plugins.extras.vscode",
+    "lazyvim.plugins.extras.ai.copilot",
+    "lazyvim.plugins.extras.ai.copilot-chat",
+    "lazyvim.plugins.extras.ai.avante"
   ],
   "install_version": 8,
   "news": {

--- a/nvim/lua/plugins/companion.lua
+++ b/nvim/lua/plugins/companion.lua
@@ -5,7 +5,15 @@ return {
     dependencies = {
       "nvim-lua/plenary.nvim",
       "nvim-treesitter/nvim-treesitter",
-      "ravitemer/mcphub.nvim",
+      {
+        "ravitemer/mcphub.nvim",
+        dependencies = {
+          "nvim-lua/plenary.nvim",
+        },
+        config = function()
+          require("mcphub").setup()
+        end,
+      },
     },
   },
   {

--- a/nvim/lua/plugins/user.lua
+++ b/nvim/lua/plugins/user.lua
@@ -33,7 +33,6 @@ return {
     "nvim-neotest/neotest-plenary",
   },
   -- diff tool
-  --
   { "akinsho/git-conflict.nvim", version = "*", config = true },
   -- linters and formarters (efm instead null-ls)
   {


### PR DESCRIPTION
This pull request primarily adds new AI-related plugins and enhances plugin dependencies in the Neovim configuration. The most significant changes are the inclusion of Copilot, Copilot Chat, and Avante plugins, as well as the integration of the `mcphub.nvim` plugin with its dependencies and setup.

### AI and Plugin Enhancements

* Added `"lazyvim.plugins.extras.ai.copilot"`, `"lazyvim.plugins.extras.ai.copilot-chat"`, and `"lazyvim.plugins.extras.ai.avante"` to the `nvim/lazyvim.json` plugin list, enabling Copilot, Copilot Chat, and Avante AI features.
* Included the `mcphub.nvim` plugin as a dependency in `nvim/lua/plugins/companion.lua`, along with its own dependency (`plenary.nvim`) and setup configuration.

### Miscellaneous

* No functional changes were made in `nvim/lua/plugins/user.lua`—only a comment was removed, so the configuration remains the same.